### PR TITLE
Add ensureValueSetsInLibrary method

### DIFF
--- a/lib/CodeService.js
+++ b/lib/CodeService.js
@@ -84,6 +84,20 @@ class CodeService {
     }
   }
 
+  /**
+   * Given a library, will detect referenced value sets and ensure that each has a local definition.  If a local definition
+   * does not exist, the value set will be downloaded using the VSAC API.
+   * @param {Object} library - the CQL Library object to look for referenced value sets in
+   * @param {boolean} checkIncluded - indicates if "included" libraries should also be checked
+   * @param {string} umlsUserName - the UMLS username to use when downloading value sets (defaults to env "UMLS_USER_NAME")
+   * @param {string} umlsPassword - the UMLS password to use when downloading value sets (defaults to env "UMLS_PASSWORD")
+   * @returns {Promise.<undefined,Error>} A promise that returns nothing when resolved and returns an error when rejected.
+   */
+  ensureValueSetsInLibrary(library, checkIncluded = true, umlsUserName = env['UMLS_USER_NAME'], umlsPassword = env['UMLS_PASSWORD']) {
+    const valueSets = extractSetOfValueSetsFromLibrary(library, checkIncluded);
+    return this.ensureValueSets(Array.from(valueSets), umlsUserName, umlsPassword);
+  }
+
   findValueSetsByOid(oid) {
     const result = [];
     const vs = this.valueSets[oid];
@@ -119,7 +133,23 @@ class CodeService {
       }
     }
   }
+}
 
+/**
+ * Extracts the referenced value sets from a CQL Library and (optionally) its included libraries
+ * @param {Object} library - the CQL Library to extract the referenced value sets from
+ * @param {boolean} extractFromIncluded - indicates if "included" libraries should be searched for referenced value sets
+ * @param {Set} valueSets - the Set of valueSets extracted so far (defaults to empty set)
+ * @returns {Set} the set of value sets referenced by the library
+ */
+function extractSetOfValueSetsFromLibrary(library, extractFromIncluded = true, valueSets = new Set()) {
+  // First add all the value sets from this library into the set
+  Object.values(library.valuesets).forEach(vs => valueSets.add(vs));
+  // Then, if requested, loop through the included libraries and add value sets from each of them
+  if (extractFromIncluded && library.includes) {
+    Object.values(library.includes).forEach(included => extractSetOfValueSetsFromLibrary(included, extractFromIncluded, valueSets));
+  }
+  return valueSets;
 }
 
 module.exports = { CodeService };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-exec-vsac",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This method will parse the library (and optionally its included libraries) to detect the referenced value sets and ensure it has local definitions for them.