### PR TITLE
Improve Support for ValueSet Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ valueset "Diabetes": 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.
 // or valueset "Diabetes": '2.16.840.1.113883.3.464.1003.103.12.1001'
 ```
 
+As of 1.1.1, this library supports Value Set versions, so the following is also supported:
+
+```
+valueset "Diabetes": 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001' version '20190315'
+// or valueset "Diabetes": 'urn:oid:2.16.840.1.113883.3.464.1003.103.12.1001' version '20190315'
+// or valueset "Diabetes": '2.16.840.1.113883.3.464.1003.103.12.1001' version '20190315'
+```
+
+When using the canonical URL as a Value Set identifier, it is also possible to embed the version directly in the URL, using a vertical bar (`|`) to separate the identifier and version:
+
+```
+valueset "Diabetes": 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001|20190315'
+```
+
+The embedded version, however, is only supported for the canonical URL form of value sets.  It is not supported for URN or OID identifiers.
+
+## Credentials Required
+
 This library requires that the credentials of a valid UMLS account be provided to it.  If you do not have an UMLS
 account, you can request one here: https://uts.nlm.nih.gov/license.html
 

--- a/lib/download-vsac.js
+++ b/lib/download-vsac.js
@@ -7,34 +7,31 @@ const extractOidAndVersion = require('./extractOidAndVersion');
 const debug = require('debug')('vsac'); // To turn on DEBUG: $ export DEBUG=vsac
 
 function downloadFromVSAC(username, password, input, output, vsDB={}, caching=true) {
-  var vsJSON = {};
-  if (typeof(input) === 'string') {
-    path.resolve(input);
-    vsJSON = require(input);
-  } else {
-    var keys = Object.keys(input);
-    keys.forEach(function(val) {
-      const [oid] = extractOidAndVersion(input[val].id);
-      if (!(oid in vsDB)) {
-        vsJSON[input[val].name] = oid;
-      }
-    });
-  }
-  if (Object.keys(vsJSON).length > 0) {
+  const oidsAndVersions = [];
+  Object.keys(input).forEach((key) => {
+    let [id, version] = [input[key].id, input[key].version];
+    const [oid, embeddedVersion] = extractOidAndVersion(id);
+    if (version == null && embeddedVersion != null) {
+      version = embeddedVersion;
+    }
+    if (vsDB[oid] == null || vsDB[oid][version] == null) {
+      oidsAndVersions.push({ oid, version });
+    }
+  });
+  if (oidsAndVersions.length) {
     output = path.resolve(output);
-    const oids = Object.keys(vsJSON).map(k => vsJSON[k]);
     if (caching && !fs.existsSync(output)){
       mkdirp.sync(output);
     }
     return getTicketGrantingTicket(username, password)
       .then((ticketGrantingTicket) => {
-        const promises = oids.map(oid => {
+        const promises = oidsAndVersions.map(({ oid, version }) => {
         // Catch errors and convert to resolutions returning an error.  This ensures Promise.all waits for all promises.
         // See: http://stackoverflow.com/questions/31424561/wait-until-all-es6-promises-complete-even-rejected-promises
-          return downloadValueSet(ticketGrantingTicket, oid, output, vsDB, caching)
+          return downloadValueSet(ticketGrantingTicket, oid, version, output, vsDB, caching)
             .catch((err) => {
-              debug(`Error downloading valueset ${oid}`, err);
-              return new Error(`Error downloading valueset: ${oid}`);
+              debug(`Error downloading valueset ${oid}${version || ''}`, err);
+              return new Error(`Error downloading valueset: ${oid}${version || ''}`);
             });
         });
         return Promise.all(promises);
@@ -68,10 +65,10 @@ function getTicketGrantingTicket(username, password) {
   return rpn(options);
 }
 
-function downloadValueSet(ticketGrantingTicket, oid, output, vsDB={}, caching=true) {
+function downloadValueSet(ticketGrantingTicket, oid, version, output, vsDB={}, caching=true) {
   return  getServiceTicket(ticketGrantingTicket)
     .then((serviceTicket) => {
-      return getValueSet(serviceTicket, oid);
+      return getValueSet(serviceTicket, oid, version);
     })
     .then((data) => {
       parseVSACXML(data, vsDB);
@@ -89,12 +86,15 @@ function getServiceTicket(ticketGrantingTicket) {
   return rpn(options);
 }
 
-function getValueSet(serviceTicket, oid) {
-  debug('Getting ValueSet:', oid);
+function getValueSet(serviceTicket, oid, version) {
+  debug(`Getting ValueSet: ${oid}${version || ''}`);
   const options = {
     url: 'https://vsac.nlm.nih.gov/vsac/svs/RetrieveValueSet',
     qs: { id: oid, ticket: serviceTicket }
   };
+  if (version != null) {
+    options.qs.version = version;
+  }
   return rpn(options);
 }
 

--- a/lib/extractOidAndVersion.js
+++ b/lib/extractOidAndVersion.js
@@ -1,8 +1,9 @@
 /**
- * Extracts just the oid from a urn, url, or oid. If it is not a valid urn or VSAC URL,
- * it is assumed to be an oid and returned as-is.
+ * Extracts the oid and version from a url, urn, or oid. Only url supports an embedded version
+ * (separately by |); urn and oid will never return a version. If the input value is not a valid
+ * urn or VSAC URL, it is assumed to be an oid and returned as-is.
  * @param {string} id - the urn, url, or oid
- * @returns {string} the oid
+ * @returns {[string,string]} the oid and optional version as a pair
  */
 function extractOidAndVersion(id) {
   if (id == null) return [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-exec-vsac",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -87,7 +87,7 @@ describe('CodeService', function() {
   });
 
   describe('#findValueSets', function() {
-    it('should find loaded values set by OID', function() {
+    it('should find loaded value sets by OID', function() {
       const oid = '2.16.840.1.113883.3.464.1003.104.12.1013';
       const results = service.findValueSets(oid);
       results.should.have.length(2);
@@ -100,7 +100,18 @@ describe('CodeService', function() {
       ]));
     });
 
-    it('should find loaded values set by URN', function() {
+    it('should find loaded value set by OID and version', function() {
+      const oid = '2.16.840.1.113883.3.464.1003.104.12.1013';
+      const version = '20170320';
+      const results = service.findValueSets(oid, version);
+      results.should.have.length(1);
+      results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20170320', [
+        new Code('2093-3', 'http://loinc.org', '2.58'),
+        new Code('48620-9', 'http://loinc.org', '2.58')
+      ]));
+    });
+
+    it('should find loaded value sets by URN', function() {
       const urn = 'urn:oid:2.16.840.1.113883.3.464.1003.104.12.1013';
       const results = service.findValueSets(urn);
       results.should.have.length(2);
@@ -113,10 +124,18 @@ describe('CodeService', function() {
       ]));
     });
 
+    it('should find loaded value sets by URN and version', function() {
+      const urn = 'urn:oid:2.16.840.1.113883.3.464.1003.104.12.1013';
+      const results = service.findValueSets(urn, '20200401');
+      results.should.have.length(1);
+      results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20200401', [
+        new Code('48620-9', 'http://loinc.org', '2.58')
+      ]));
+    });
 
-    it('should find loaded values set by https URL', function() {
-      const urn = 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013';
-      const results = service.findValueSets(urn);
+    it('should find loaded value sets by https URL', function() {
+      const url = 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013';
+      const results = service.findValueSets(url);
       results.should.have.length(2);
       results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20170320', [
         new Code('2093-3', 'http://loinc.org', '2.58'),
@@ -127,22 +146,9 @@ describe('CodeService', function() {
       ]));
     });
 
-    it('should find loaded values set by http URL', function() {
-      const urn = 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013';
-      const results = service.findValueSets(urn);
-      results.should.have.length(2);
-      results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20170320', [
-        new Code('2093-3', 'http://loinc.org', '2.58'),
-        new Code('48620-9', 'http://loinc.org', '2.58')
-      ]));
-      results[1].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20200401', [
-        new Code('48620-9', 'http://loinc.org', '2.58')
-      ]));
-    });
-
-    it('should find loaded value set by https URL with version', function() {
-      const urn = 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20170320';
-      const results = service.findValueSets(urn);
+    it('should find loaded value sets by https URL and version', function() {
+      const url = 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013';
+      const results = service.findValueSets(url, '20170320');
       results.should.have.length(1);
       results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20170320', [
         new Code('2093-3', 'http://loinc.org', '2.58'),
@@ -150,9 +156,61 @@ describe('CodeService', function() {
       ]));
     });
 
-    it('should find loaded value set by http URL with version', function() {
-      const urn = 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20170320';
-      const results = service.findValueSets(urn);
+    it('should find loaded values sets by http URL', function() {
+      const url = 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013';
+      const results = service.findValueSets(url);
+      results.should.have.length(2);
+      results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20170320', [
+        new Code('2093-3', 'http://loinc.org', '2.58'),
+        new Code('48620-9', 'http://loinc.org', '2.58')
+      ]));
+      results[1].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20200401', [
+        new Code('48620-9', 'http://loinc.org', '2.58')
+      ]));
+    });
+
+    it('should find loaded values sets by http URL and version', function() {
+      const url = 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013';
+      const results = service.findValueSets(url, '20200401');
+      results.should.have.length(1);
+      results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20200401', [
+        new Code('48620-9', 'http://loinc.org', '2.58')
+      ]));
+    });
+
+    it('should find loaded value set by https URL with embedded version', function() {
+      const url = 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20170320';
+      const results = service.findValueSets(url);
+      results.should.have.length(1);
+      results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20170320', [
+        new Code('2093-3', 'http://loinc.org', '2.58'),
+        new Code('48620-9', 'http://loinc.org', '2.58')
+      ]));
+    });
+
+    it('should prefer explicit version over embedded version in https URL', function() {
+      const url = 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20200401';
+      const results = service.findValueSets(url, '20170320');
+      results.should.have.length(1);
+      results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20170320', [
+        new Code('2093-3', 'http://loinc.org', '2.58'),
+        new Code('48620-9', 'http://loinc.org', '2.58')
+      ]));
+    });
+
+    it('should find loaded value set by http URL with embedded version', function() {
+      const url = 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20170320';
+      const results = service.findValueSets(url);
+      results.should.have.length(1);
+      results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20170320', [
+        new Code('2093-3', 'http://loinc.org', '2.58'),
+        new Code('48620-9', 'http://loinc.org', '2.58')
+      ]));
+    });
+
+    it('should prefer explicit version over embedded version in http URL', function() {
+      const url = 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20200401';
+      const results = service.findValueSets(url, '20170320');
       results.should.have.length(1);
       results[0].should.eql(new ValueSet('2.16.840.1.113883.3.464.1003.104.12.1013', '20170320', [
         new Code('2093-3', 'http://loinc.org', '2.58'),
@@ -165,8 +223,18 @@ describe('CodeService', function() {
       results.should.be.empty;
     });
 
+    it('should not find invalid value set version by OID', function() {
+      const results = service.findValueSets('2.16.840.1.113883.3.464.1003.104.12.1013', '20180320');
+      results.should.be.empty;
+    });
+
     it('should not find invalid value set by URN', function() {
       const results = service.findValueSets('urn:oid:FOO');
+      results.should.be.empty;
+    });
+
+    it('should not find invalid value set version by URN', function() {
+      const results = service.findValueSets('urn:oid:2.16.840.1.113883.3.464.1003.104.12.1013', '20180320');
       results.should.be.empty;
     });
 
@@ -175,17 +243,27 @@ describe('CodeService', function() {
       results.should.be.empty;
     });
 
+    it('should not find invalid value set version by https URL', function() {
+      const results = service.findValueSets('https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013', '20180320');
+      results.should.be.empty;
+    });
+
+    it('should not find value set by https URL with invalid embedded version', function() {
+      const results = service.findValueSets('https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20180320');
+      results.should.be.empty;
+    });
+
     it('should not find invalid value set by http URL', function() {
       const results = service.findValueSets('http://cts.nlm.nih.gov/fhir/ValueSet/FOO');
       results.should.be.empty;
     });
 
-    it('should not find value set by https URL with invalid version', function() {
-      const results = service.findValueSets('https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20180320');
+    it('should not find invalid value set version by http URL', function() {
+      const results = service.findValueSets('http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013', '20180320');
       results.should.be.empty;
     });
 
-    it('should not find value set by http URL with invalid version', function() {
+    it('should not find value set by http URL with invalid embedded version', function() {
       const results = service.findValueSets('http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20180320');
       results.should.be.empty;
     });
@@ -313,12 +391,26 @@ describe('CodeService', function() {
   describe('#ensureValueSets', function() {
     it('should not attempt downloads for value sets it already has (by OID)', function() {
       const vsList = [
+        {name: 'HDL Cholesterol', id: '2.16.840.1.113883.3.464.1003.104.12.1013'}
+      ];
+      return service.ensureValueSets(vsList).should.be.fulfilled;
+    });
+
+    it('should not attempt downloads for value sets it already has (by OID and version)', function() {
+      const vsList = [
         {name: 'HDL Cholesterol', id: '2.16.840.1.113883.3.464.1003.104.12.1013', version: '20170320'}
       ];
       return service.ensureValueSets(vsList).should.be.fulfilled;
     });
 
     it('should not attempt downloads for value sets it already has (by URN)', function() {
+      const vsList = [
+        {name: 'HDL Cholesterol', id: 'urn:oid:2.16.840.1.113883.3.464.1003.104.12.1013'}
+      ];
+      return service.ensureValueSets(vsList).should.be.fulfilled;
+    });
+
+    it('should not attempt downloads for value sets it already has (by URN and version)', function() {
       const vsList = [
         {name: 'HDL Cholesterol', id: 'urn:oid:2.16.840.1.113883.3.464.1003.104.12.1013', version: '20170320'}
       ];
@@ -327,12 +419,27 @@ describe('CodeService', function() {
 
     it('should not attempt downloads for value sets it already has (by https URL)', function() {
       const vsList = [
+        {name: 'HDL Cholesterol', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013'}
+      ];
+      return service.ensureValueSets(vsList).should.be.fulfilled;
+    });
+
+    it('should not attempt downloads for value sets it already has (by https URL and version)', function() {
+      const vsList = [
         {name: 'HDL Cholesterol', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013', version: '20170320'}
       ];
       return service.ensureValueSets(vsList).should.be.fulfilled;
     });
 
     it('should not attempt downloads for value sets it already has (by http URL)', function() {
+      const vsList = [
+        {name: 'HDL Cholesterol', id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013'}
+      ];
+      return service.ensureValueSets(vsList).should.be.fulfilled;
+    });
+
+
+    it('should not attempt downloads for value sets it already has (by http URL and version)', function() {
       const vsList = [
         {name: 'HDL Cholesterol', id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013', version: '20170320'}
       ];
@@ -355,51 +462,16 @@ describe('CodeService', function() {
 
     it('should download value sets it does not have (by OID)', function() {
       return doDownloadTest([
-        {name: 'Systolic Blood Pressure', id: '2.16.840.1.113883.3.526.3.1032', version: '20170320'},
-        {name: 'Current Tobacco Smoker', id: '2.16.840.1.113883.3.600.2390', version: '20170320'}
-      ]);
-    });
-
-    it('should download value sets it does not have (by URN)', function() {
-      return doDownloadTest([
-        {name: 'Systolic Blood Pressure', id: 'urn:oid:2.16.840.1.113883.3.526.3.1032', version: '20170320'},
-        {name: 'Current Tobacco Smoker', id: 'urn:oid:2.16.840.1.113883.3.600.2390', version: '20170320'}
-      ]);
-    });
-
-    it('should download value sets it does not have (by https URL)', function() {
-      return doDownloadTest([
-        {name: 'Systolic Blood Pressure', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032', version: '20170320'},
-        {name: 'Current Tobacco Smoker', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390', version: '20170320'}
-      ]);
-    });
-
-    it('should download value sets it does not have (by http URL)', function() {
-      return doDownloadTest([
-        {name: 'Systolic Blood Pressure', id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032', version: '20170320'},
-        {name: 'Current Tobacco Smoker', id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390', version: '20170320'}
-      ]);
-    });
-
-    it('should download value sets it does not have (by https URL with embedded version)', function() {
-      return doDownloadTest([
-        {name: 'Systolic Blood Pressure', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032|20170320'},
-        {name: 'Current Tobacco Smoker', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390|20170320'}
-      ]);
-    });
-
-    it('should download value sets it does not have (by http URL with embedded version)', function() {
-      return doDownloadTest([
-        {name: 'Systolic Blood Pressure', id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032|20170320'},
-        {name: 'Current Tobacco Smoker', id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390|20170320'}
-      ]);
-    });
-
-    it('should download value sets it does not have when no version is supplied (by OID)', function() {
-      return doDownloadTest([
         {name: 'Systolic Blood Pressure', id: '2.16.840.1.113883.3.526.3.1032'},
         {name: 'Current Tobacco Smoker', id: '2.16.840.1.113883.3.600.2390'}
       ]);
+    });
+
+    it('should download value sets it does not have (by OID and version)', function() {
+      return doDownloadTest([
+        {name: 'Systolic Blood Pressure', id: '2.16.840.1.113883.3.526.3.1032', version: '20170320'},
+        {name: 'Current Tobacco Smoker', id: '2.16.840.1.113883.3.600.2390', version: '20170320'}
+      ], true);
     });
 
     it('should download value sets it does not have when no version is supplied (by URN)', function() {
@@ -409,11 +481,32 @@ describe('CodeService', function() {
       ]);
     });
 
+    it('should download value sets it does not have (by URN and version)', function() {
+      return doDownloadTest([
+        {name: 'Systolic Blood Pressure', id: 'urn:oid:2.16.840.1.113883.3.526.3.1032', version: '20170320'},
+        {name: 'Current Tobacco Smoker', id: 'urn:oid:2.16.840.1.113883.3.600.2390', version: '20170320'}
+      ], true);
+    });
+
     it('should download value sets it does not have when no version is supplied (by https URL)', function() {
       return doDownloadTest([
         {name: 'Systolic Blood Pressure', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032'},
         {name: 'Current Tobacco Smoker', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390'}
       ]);
+    });
+
+    it('should download value sets it does not have (by https URL and version)', function() {
+      return doDownloadTest([
+        {name: 'Systolic Blood Pressure', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032', version: '20170320'},
+        {name: 'Current Tobacco Smoker', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390', version: '20170320'}
+      ], true);
+    });
+
+    it('should download value sets it does not have (by https URL with embedded version)', function() {
+      return doDownloadTest([
+        {name: 'Systolic Blood Pressure', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032|20170320'},
+        {name: 'Current Tobacco Smoker', id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390|20170320'}
+      ], true);
     });
 
     it('should download value sets it does not have when no version is supplied (by http URL)', function() {
@@ -423,10 +516,30 @@ describe('CodeService', function() {
       ]);
     });
 
-    const doDownloadTest = (vsList) => {
+    it('should download value sets it does not have (by http URL and version)', function() {
+      return doDownloadTest([
+        {name: 'Systolic Blood Pressure', id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032', version: '20170320'},
+        {name: 'Current Tobacco Smoker', id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390', version: '20170320'}
+      ], true);
+    });
+
+    it('should download value sets it does not have (by http URL with embedded version)', function() {
+      return doDownloadTest([
+        {name: 'Systolic Blood Pressure', id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032|20170320'},
+        {name: 'Current Tobacco Smoker', id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390|20170320'}
+      ], true);
+    });
+
+    const doDownloadTest = (vsList, withVersion = false) => {
       // Just to be sure, check length is only 2 (as expected)
       Object.keys(service.valueSets).should.have.length(2);
 
+      const query1 = { id: '2.16.840.1.113883.3.526.3.1032', ticket: 'ST-TEST-1' };
+      const query2 = { id: '2.16.840.1.113883.3.600.2390', ticket: 'ST-TEST-2' };
+      if (withVersion) {
+        query1.version = '20170320';
+        query2.version = '20170320';
+      }
       nock('https://vsac.nlm.nih.gov')
         // Ticket granting ticket
         .post('/vsac/ws/Ticket', { username, password })
@@ -435,13 +548,13 @@ describe('CodeService', function() {
         .post('/vsac/ws/Ticket/TGT-TEST', { service: 'http://umlsks.nlm.nih.gov' })
         .reply(200, 'ST-TEST-1')
         .get('/vsac/svs/RetrieveValueSet')
-        .query({ id: '2.16.840.1.113883.3.526.3.1032', ticket: 'ST-TEST-1' })
+        .query(query1)
         .replyWithFile(200, path.join(__dirname, 'fixtures', '2.16.840.1.113883.3.526.3.1032.xml'))
         // Service ticket and VS retrieval #2
         .post('/vsac/ws/Ticket/TGT-TEST', { service: 'http://umlsks.nlm.nih.gov' })
         .reply(200, 'ST-TEST-2')
         .get('/vsac/svs/RetrieveValueSet')
-        .query({ id: '2.16.840.1.113883.3.600.2390', ticket: 'ST-TEST-2' })
+        .query(query2)
         .replyWithFile(200, path.join(__dirname, 'fixtures', '2.16.840.1.113883.3.600.2390.xml'));
 
       return service.ensureValueSets(vsList, username, password).then(function() {
@@ -455,7 +568,7 @@ describe('CodeService', function() {
         // Test that the value sets were properly written to the cache
         const cached = require(path.join(tmpCache, 'valueset-db.json'));
         JSON.parse(JSON.stringify(service.valueSets)).should.eql(cached);
-      }).catch((err) => console.log(err));
+      });//.catch((err) => console.log(err));
     };
 
     it('should download and cache successful value sets before throwing error', function() {
@@ -470,13 +583,13 @@ describe('CodeService', function() {
         .post('/vsac/ws/Ticket/TGT-TEST', { service: 'http://umlsks.nlm.nih.gov' })
         .reply(200, 'ST-TEST-1')
         .get('/vsac/svs/RetrieveValueSet')
-        .query({ id: '1.2.3.4.5.6.7.8.9.10', ticket: 'ST-TEST-1' })
+        .query({ id: '1.2.3.4.5.6.7.8.9.10', version: '20170320', ticket: 'ST-TEST-1' })
         .reply(404) // Not Found
         // Service ticket and VS retrieval #2
         .post('/vsac/ws/Ticket/TGT-TEST', { service: 'http://umlsks.nlm.nih.gov' })
         .reply(200, 'ST-TEST-2')
         .get('/vsac/svs/RetrieveValueSet')
-        .query({ id: '2.16.840.1.113883.3.600.2390', ticket: 'ST-TEST-2' })
+        .query({ id: '2.16.840.1.113883.3.600.2390', version: '20170320', ticket: 'ST-TEST-2' })
         .replyWithFile(200, path.join(__dirname, 'fixtures', '2.16.840.1.113883.3.600.2390.xml'));
 
       const vsList = [
@@ -585,7 +698,7 @@ describe('CodeService', function() {
         .reply(200, 'ST-INVALID-TEST')
         // Simulate response to requesting value set w/ invalid service granting ticket
         .get('/vsac/svs/RetrieveValueSet')
-        .query({ id: '2.16.840.1.113883.3.526.3.1032', ticket: 'ST-INVALID-TEST' })
+        .query({ id: '2.16.840.1.113883.3.526.3.1032', version: '20170320', ticket: 'ST-INVALID-TEST' })
         .reply(401, 'Unauthorized'); // This is the only one that puts 'Unauthorized' in the body
 
       const vsList = [
@@ -612,7 +725,7 @@ describe('CodeService', function() {
         .post('/vsac/ws/Ticket/TGT-TEST', { service: 'http://umlsks.nlm.nih.gov' })
         .reply(200, 'ST-TEST')
         .get('/vsac/svs/RetrieveValueSet')
-        .query({ id: '1.2.3.4.5.6.7.8.9.10', ticket: 'ST-TEST' })
+        .query({ id: '1.2.3.4.5.6.7.8.9.10', version: '20170320', ticket: 'ST-TEST' })
         .reply(404); // Not Found
 
       const vsList = [


### PR DESCRIPTION
Previous to this PR, `cql-exec-vsac` supported looking up cached value sets by specific versions -- but it completely ignored version when downloading value sets (it always downloaded the latest).  Now, if a value set version is specifically requested, it will download that specific version (if that version is not already in the cache).

The unit tests show this working, but if you want to test it IRL, here is one way you could test it:
1. First you need to build a tgz of the updated cql-exec-vsac from this branch. Do this by checking out this branch, running `yarn install` and then running `yarn pack`.  This will create a file named `cql-exec-vsac-v1.1.1.tgz`.
2. Then clone (or pull) the [Pain Management Summary](https://github.com/AHRQ-CDS/AHRQ-CDS-Connect-PAIN-MANAGEMENT-SUMMARY).
3. Open up the following file from the Pain Management Summary codebase in your favorite editor: `src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.json`
4. Add the following to the ValueSet definitions around line 60:
    ```json
    {
      "name" : "C19HCC SARS coronavirus 2 Qualitative Detection Laboratory Tests",
      "id" : "2.16.840.1.113762.1.4.1032.109",
      "version": "20200417",
      "accessLevel" : "Public"
    },
    ```
5. From the Pain Management Summary project, run the following command (substituting your UMLS username and password):
    ```
    node node src/utils/updateValueSetDB.js myUMLSUsername MyUMLSPassword
    ```
    This is downloading the value sets using the old cql-exec-vsac that does not support downloading by version.
6. Open up the following file in your favorite editor: `src/cql/valueset-db.json`
7. Search for `2.16.840.1.113762.1.4.1032.109` and note that it contains an empty set of codes:
    ```json
    "2.16.840.1.113762.1.4.1032.109": {
      "20200417": []
    },
    ```
8. Now upgrade cql-exec-vsac in the Pain Management Summary via a command like the following (substituting the path to the tgz you created in step 1:
    ```
    yarn upgrade cql-exec-vsac@file:path/to/cql-exec-vsac/cql-exec-vsac-v1.1.1.tgz
    ```
9. Repeat step 5 to update the valueset-db.json file using the new cql-exec-vsac.
10. Open the `valueset-db.json` file again and search for `2.16.840.1.113762.1.4.1032.109` again. If this is working, you'll see that it now contains a small number of codes:
    ```json5
    "2.16.840.1.113762.1.4.1032.109": {
      "20200417": [
        {
          "code": "94307-6",
          "system": "http://loinc.org",
          "version": "Provisional_2020-03-31"
        },
        {
          "code": "94308-4",
          "system": "http://loinc.org",
          "version": "Provisional_2020-03-31"
        },
        // etc.
      ]
    },
    ```