### PR TITLE
Remove deprecated ensureValueSets and ensureValueSetsInLibrary methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ valueset "Diabetes": 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.
 // or valueset "Diabetes": '2.16.840.1.113883.3.464.1003.103.12.1001' version '20190315'
 ```
 
-When using the canonical URL as a Value Set identifier, it is also possible to embed the version directly in the URL, using a vertical bar (`|`) to separate the identifier and version:
+When using the canonical URL as a Value Set identifier, it is also possible to embed the version directly in the URL,
+using a vertical bar (`|`) to separate the identifier and version:
 
 ```
 valueset "Diabetes": 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001|20190315'
 ```
 
-The embedded version, however, is only supported for the canonical URL form of value sets.  It is not supported for URN or OID identifiers.
+The embedded version, however, is only supported for the canonical URL form of value sets.  It is not supported for URN
+or OID identifiers.
 
 ## Credentials Required
 
@@ -50,35 +52,42 @@ prevents the code service from having to make multiple calls to VSAC for the sam
 
 The second argument to the `CodeService` constructor is a boolean indicating if the code service should begin by
 loading existing value sets from the cache.  If true, it will initialize the code service from the cache (if the
-cache exists and is populated).  If false, `ensureValueSets` will re-download any value sets passed to it, overwriting
-the cache.
+cache exists and is populated).  If false, `ensureValueSetsWithAPIKey` will re-download any value sets passed to it,
+overwriting the cache.
 
 ## Using UMLS Credentials
 
-Downloading value set definitions from VSAC requires a valid UMLS account.  The code service's `ensureValueSets`
-function allows a UMLS username and password to be passed in.  Alternately, the UMLS username and password can be
-provided via `UMLS_USER_NAME` and `UMLS_PASSWORD` environment variables.
-
-**NOTE**: As of Jan 1 2021 VSAC will no longer accept accept username and password and will require an API key.  The code 
-service's `ensureValueSetsWithAPIKey` allows a UMLS API key to be passed in.  Alternatively, the UMLS API key can be
-provided via `UMLS_API_KEY` environment variables.
+Downloading value set definitions from VSAC requires a valid UMLS account.  The code service's
+`ensureValueSetsWithAPIKey` function allows a UMLS API key to be passed in.  Alternately, the UMLS API key can be
+provided via the `UMLS_API_KEY` environment variable.
 
 ## Downloading Value Set Definitions
 
-The `ensureValueSets` and `ensureValueSetsInLibrary` functions are the only functions that attempt to download value
-sets from VSAC.  Before they make a request to VSAC, they will check the cache.  If the value set is already in the
-cache, they will not make a request to VSAC.  Otherwise, they will use VSAC's SVS2 API to download the expanded codes
-from the value set.
+The `ensureValueSetsWithAPIKey` and `ensureValueSetsInLibraryWithAPIKey` functions are the only functions that attempt
+to download value sets from VSAC.  Before they make a request to VSAC, they will check the cache.  If the value set is
+already in the cache, they will not make a request to VSAC.  Otherwise, they will use VSAC's SVS2 API to download the
+expanded codes from the value set.
 
 The `findValueSet` and `findValueSets` functions (including the legacy `findValueSetsByOid` function) do not reach out
-to VSAC, so implementations should call `ensureValueSetsInLibrary` or `ensureValueSets` before attempting to execute
-CQL.  If `ensureValueSets` is used, the implementor is responsible for passing in the OIDs / versions that will be
-needed.
+to VSAC, so implementations should call `ensureValueSetsInLibraryWithAPIKey` or `ensureValueSetsWithAPIKey` before
+attempting to execute CQL.  If `ensureValueSetsWithAPIKey` is used, the implementor is responsible for passing in the
+OIDs / versions that will be needed.
+
+## Breaking Changes in Version 2.0.0
+
+Version 2.0.0 of the code service removes the old `ensureValueSets` and `ensureValueSetsinLibrary` methods that
+accepted a UMLS user name and password. As of Jan 1, 2021, VSAC no longer allows API authentication using username and
+password. Instead, implementations should now use `ensureValueSetsWithAPIKey` and `ensureValueSetsinLibraryWithApiKey`,
+each of which allows an API key to be passed in (or to be specified via the `UMLS_API_KEY` environment variables).
+
+In addition, version 2.0.0 switched its communication library from [request](https://www.npmjs.com/package/request)
+to [node-fetch](https://www.npmjs.com/package/node-fetch). This should be transparent in most cases, but some thrown
+errors may have a different format since they are thrown by _node-fetch_ rather than _request_.
 
 ## Example
 
-The following is a simple example of setting up the VSAC Code Service, calling `ensureValueSets`, and passing the
-Code Service into the CQL Execution engine:
+The following is a simple example of setting up the VSAC Code Service, calling `ensureValueSetsinLibraryWithApiKey`,
+and passing the Code Service into the CQL Execution engine:
 
 ```js
 const vsac = require('cql-exec-vsac');
@@ -89,7 +98,7 @@ const vsac = require('cql-exec-vsac');
 // Set up the code service, loading from the cache if it exists
 const codeService = new vsac.CodeService('/path/to/vsac_cache', true);
 // Ensure value sets in the library and its dependencies, downloading any missing value sets
-codeService.ensureValueSetsInLibrary(library, true, 'myUMLSUserName', 'myUMLSPassword')
+codeService.ensureValueSetsinLibraryWithApiKey(library, true, 'myUmlsApiKey')
 .then(() => {
   // Value sets are loaded, so execute!
   const executor = new cql.Executor(lib, codeService, parameters);

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ OIDs / versions that will be needed.
 
 ## Breaking Changes in Version 2.0.0
 
-Version 2.0.0 of the code service removes the old `ensureValueSets` and `ensureValueSetsinLibrary` methods that
+Version 2.0.0 of the code service removes the old `ensureValueSets` and `ensureValueSetsInLibrary` methods that
 accepted a UMLS user name and password. As of Jan 1, 2021, VSAC no longer allows API authentication using username and
-password. Instead, implementations should now use `ensureValueSetsWithAPIKey` and `ensureValueSetsinLibraryWithApiKey`,
+password. Instead, implementations should now use `ensureValueSetsWithAPIKey` and `ensureValueSetsInLibraryWithApiKey`,
 each of which allows an API key to be passed in (or to be specified via the `UMLS_API_KEY` environment variables).
 
 In addition, version 2.0.0 switched its communication library from [request](https://www.npmjs.com/package/request)
@@ -86,7 +86,7 @@ errors may have a different format since they are thrown by _node-fetch_ rather 
 
 ## Example
 
-The following is a simple example of setting up the VSAC Code Service, calling `ensureValueSetsinLibraryWithApiKey`,
+The following is a simple example of setting up the VSAC Code Service, calling `ensureValueSetsInLibraryWithApiKey`,
 and passing the Code Service into the CQL Execution engine:
 
 ```js
@@ -98,7 +98,7 @@ const vsac = require('cql-exec-vsac');
 // Set up the code service, loading from the cache if it exists
 const codeService = new vsac.CodeService('/path/to/vsac_cache', true);
 // Ensure value sets in the library and its dependencies, downloading any missing value sets
-codeService.ensureValueSetsinLibraryWithApiKey(library, true, 'myUmlsApiKey')
+codeService.ensureValueSetsInLibraryWithApiKey(library, true, 'myUmlsApiKey')
 .then(() => {
   // Value sets are loaded, so execute!
   const executor = new cql.Executor(lib, codeService, parameters);

--- a/manual-test.js
+++ b/manual-test.js
@@ -9,11 +9,7 @@ const VALUESET = {
 };
 
 async function main() {
-  if (
-    env['UMLS_USER_NAME'] == null &&
-    env['UMLS_PASSWORD'] == null &&
-    env['UMLS_API_KEY'] == null
-  ) {
+  if (env['UMLS_API_KEY'] == null) {
     console.error('This test requires you to set the UMLS_API_KEY environment variable');
     process.exit(1);
   }

--- a/src/CodeService.js
+++ b/src/CodeService.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const proc = require('process');
 const env = proc.env;
 const path = require('path');
-const { downloadFromVSAC, downloadFromVSACWithAPIKey } = require('./download-vsac');
+const { downloadFromVSACWithAPIKey } = require('./download-vsac');
 const extractOidAndVersion = require('./extractOidAndVersion');
 
 /**
@@ -66,55 +66,6 @@ class CodeService {
    * Given a list of value set references, will ensure that each has a local
    * definition.  If a local definition does not exist, the value set will
    * be downloaded using the VSAC API.
-   * @deprecated As of Jan 1 2021 VSAC will no longer accept accept username and password.
-   *   Please use ensureValueSetsWithAPIKey() instead.
-   * @param {Object} valueSetList - an array of objects, each containing "name"
-   *   and "id" properties, with an optional "version" property
-   * @returns {Promise.<undefined,Error>} A promise that returns nothing when
-   *   resolved and returns an error when rejected.
-   */
-  ensureValueSets(
-    valueSetList = [],
-    umlsUserName = env['UMLS_USER_NAME'],
-    umlsPassword = env['UMLS_PASSWORD'],
-    caching = true
-  ) {
-    console.warn(
-      'WARNING! As of Jan 1 2021 VSAC will no longer accept accept username and password.  As such ' +
-        'ensureValueSets() has been deprecated, please use the new ensureValueSetsWithAPIKey() function instead!'
-    );
-    // First, filter out the value sets we already have
-    const filteredVSList = valueSetList.filter(vs => {
-      const result = this.findValueSet(vs.id, vs.version);
-      return typeof result === 'undefined';
-    });
-    // Now download from VSAC if necessary
-    if (filteredVSList.length == 0) {
-      return Promise.resolve();
-    } else if (
-      typeof umlsUserName === 'undefined' ||
-      umlsUserName == null ||
-      typeof umlsPassword === 'undefined' ||
-      umlsPassword == null
-    ) {
-      return Promise.reject(
-        'Failed to download value sets since UMLS_USER_NAME and/or UMLS_PASSWORD is not set.'
-      );
-    } else {
-      return downloadFromVSAC(
-        umlsUserName,
-        umlsPassword,
-        filteredVSList,
-        this.cache,
-        this.valueSets,
-        caching
-      );
-    }
-  }
-  /**
-   * Given a list of value set references, will ensure that each has a local
-   * definition.  If a local definition does not exist, the value set will
-   * be downloaded using the VSAC API.
    * @param {Object} valueSetList - an array of objects, each containing "name"
    *   and "id" properties, with an optional "version" property
    * @returns {Promise.<undefined,Error>} A promise that returns nothing when
@@ -145,35 +96,9 @@ class CodeService {
   /**
    * Given a library, will detect referenced value sets and ensure that each has a local definition.  If a local definition
    * does not exist, the value set will be downloaded using the VSAC API.
-   * @deprecated As of Jan 1 2021 VSAC will no longer accept accept username and password. Please use
-   *   ensureValueSetsInLibraryWithAPIKey() instead.
    * @param {Object} library - the CQL Library object to look for referenced value sets in
    * @param {boolean} checkIncluded - indicates if "included" libraries should also be checked
-   * @param {string} umlsUserName - the UMLS username to use when downloading value sets (defaults to env "UMLS_USER_NAME")
-   * @param {string} umlsPassword - the UMLS password to use when downloading value sets (defaults to env "UMLS_PASSWORD")
-   * @returns {Promise.<undefined,Error>} A promise that returns nothing when resolved and returns an error when rejected.
-   */
-  ensureValueSetsInLibrary(
-    library,
-    checkIncluded = true,
-    umlsUserName = env['UMLS_USER_NAME'],
-    umlsPassword = env['UMLS_PASSWORD'],
-    caching = true
-  ) {
-    console.warn(
-      'WARNING! As of Jan 1 2021 VSAC will no longer accept accept username and password.  As such ' +
-        'ensureValueSetsInLibrary() has been deprecated, please use the new ensureValueSetsInLibraryWithAPIKey() function instead!'
-    );
-    const valueSets = extractSetOfValueSetsFromLibrary(library, checkIncluded);
-    return this.ensureValueSets(Array.from(valueSets), umlsUserName, umlsPassword, caching);
-  }
-
-  /**
-   * Given a library, will detect referenced value sets and ensure that each has a local definition.  If a local definition
-   * does not exist, the value set will be downloaded using the VSAC API.
-   * @param {Object} library - the CQL Library object to look for referenced value sets in
-   * @param {boolean} checkIncluded - indicates if "included" libraries should also be checked
-   * @param {string} umlsAPIKey - the UMLS API Key to use when downloading value sets (defaults to env "UMLS_USER_NAME")
+   * @param {string} umlsAPIKey - the UMLS API Key to use when downloading value sets
    * @returns {Promise.<undefined,Error>} A promise that returns nothing when resolved and returns an error when rejected.
    */
   ensureValueSetsInLibraryWithAPIKey(

--- a/src/download-vsac.js
+++ b/src/download-vsac.js
@@ -6,66 +6,6 @@ const parseVSACXML = require('./parse-vsac');
 const extractOidAndVersion = require('./extractOidAndVersion');
 const debug = require('debug')('vsac'); // To turn on DEBUG: $ export DEBUG=vsac
 
-/*
- * @deprecated:  As of Jan 1 2021 VSAC will no longer accept accept username and password.
- * Please use downloadFromVSACWithAPIKey instead.
- */
-function downloadFromVSAC(username, password, input, output, vsDB = {}, caching = true) {
-  const oidsAndVersions = [];
-  Object.keys(input).forEach(key => {
-    let [id, version] = [input[key].id, input[key].version];
-    const [oid, embeddedVersion] = extractOidAndVersion(id);
-    if (version == null && embeddedVersion != null) {
-      version = embeddedVersion;
-    }
-    if (vsDB[oid] == null || vsDB[oid][version] == null) {
-      oidsAndVersions.push({ oid, version });
-    }
-  });
-  if (oidsAndVersions.length) {
-    output = path.resolve(output);
-    if (caching && !fs.existsSync(output)) {
-      mkdirp.sync(output);
-    }
-    return getTicketGrantingTicket(username, password)
-      .then(ticketGrantingTicket => {
-        const promises = oidsAndVersions.map(({ oid, version }) => {
-          // Catch errors and convert to resolutions returning an error.  This ensures Promise.all waits for all promises.
-          // See: http://stackoverflow.com/questions/31424561/wait-until-all-es6-promises-complete-even-rejected-promises
-          return downloadValueSet(ticketGrantingTicket, oid, version, output, vsDB, caching).catch(
-            err => {
-              debug(`Error downloading valueset ${oid}${version || ''}`, err);
-              return new Error(`Error downloading valueset: ${oid}${version || ''}`);
-            }
-          );
-        });
-        return Promise.all(promises);
-      })
-      .then(results => {
-        const errors = results.filter(r => r instanceof Error);
-        if (results.length - errors.length > 0) {
-          // There were results, so write the file first before resolving/rejecting
-          return writeFile(
-            path.join(output, 'valueset-db.json'),
-            JSON.stringify(vsDB, null, 2),
-            caching
-          ).then(
-            result => (errors.length == 0 ? result : Promise.reject(errors)),
-            err => {
-              errors.push(err);
-              return Promise.reject(errors);
-            }
-          );
-        }
-        if (errors.length > 0) {
-          return Promise.reject(errors);
-        }
-      });
-  } else {
-    return Promise.resolve();
-  }
-}
-
 function downloadFromVSACWithAPIKey(apiKey, input, output, vsDB = {}, caching = true) {
   const oidsAndVersions = [];
   Object.keys(input).forEach(key => {
@@ -120,27 +60,6 @@ function downloadFromVSACWithAPIKey(apiKey, input, output, vsDB = {}, caching = 
   } else {
     return Promise.resolve();
   }
-}
-
-/*
- * @deprecated: As of Jan 1 2021 VSAC will no longer accept accept username and password.
- * Please use getTicketGrantingTicketWithAPIKey instead.
- */
-function getTicketGrantingTicket(username, password) {
-  debug('Getting TGT');
-  const params = new URLSearchParams();
-  params.append('username', username);
-  params.append('password', password);
-  const options = {
-    method: 'POST',
-    body: params
-  };
-  return fetch('https://vsac.nlm.nih.gov/vsac/ws/Ticket', options).then(res => {
-    if (!res.ok) {
-      throw new Error(res.status);
-    }
-    return res.text();
-  });
 }
 
 function getTicketGrantingTicketWithAPIKey(apiKey) {
@@ -223,4 +142,4 @@ function writeFile(file, data, caching = true) {
   });
 }
 
-module.exports = { downloadFromVSAC, downloadFromVSACWithAPIKey };
+module.exports = { downloadFromVSACWithAPIKey };

--- a/test/test.js
+++ b/test/test.js
@@ -12,8 +12,6 @@ const should = chai.should();
 
 describe('CodeService', function () {
   let service, tmpCache;
-  const username = process.env['UMLS_USER_NAME'] || 'testuser1';
-  const password = process.env['UMLS_PASSWORD'] || 'testpassword23';
   const apiKey = process.env['UMLS_API_KEY'] || 'testkey';
 
   before(function () {
@@ -464,321 +462,6 @@ describe('CodeService', function () {
     });
   });
 
-  //Tests using username/password for auth
-  console.warn(
-    'WARNING! As of Jan 1 2021 VSAC will no longer accept accept username and password.  As such ' +
-      'ensureValueSets has been deprecated'
-  );
-  describe('#ensureValueSets', function () {
-    it('should not attempt downloads for value sets it already has (by OID)', function () {
-      const vsList = [
-        {
-          name: 'HDL Cholesterol',
-          id: '2.16.840.1.113883.3.464.1003.104.12.1013'
-        }
-      ];
-      return service.ensureValueSets(vsList).should.be.fulfilled;
-    });
-
-    it('should not attempt downloads for value sets it already has (by OID and version)', function () {
-      const vsList = [
-        {
-          name: 'HDL Cholesterol',
-          id: '2.16.840.1.113883.3.464.1003.104.12.1013',
-          version: '20170320'
-        }
-      ];
-      return service.ensureValueSets(vsList).should.be.fulfilled;
-    });
-
-    it('should not attempt downloads for value sets it already has (by URN)', function () {
-      const vsList = [
-        {
-          name: 'HDL Cholesterol',
-          id: 'urn:oid:2.16.840.1.113883.3.464.1003.104.12.1013'
-        }
-      ];
-      return service.ensureValueSets(vsList).should.be.fulfilled;
-    });
-
-    it('should not attempt downloads for value sets it already has (by URN and version)', function () {
-      const vsList = [
-        {
-          name: 'HDL Cholesterol',
-          id: 'urn:oid:2.16.840.1.113883.3.464.1003.104.12.1013',
-          version: '20170320'
-        }
-      ];
-      return service.ensureValueSets(vsList).should.be.fulfilled;
-    });
-
-    it('should not attempt downloads for value sets it already has (by https URL)', function () {
-      const vsList = [
-        {
-          name: 'HDL Cholesterol',
-          id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013'
-        }
-      ];
-      return service.ensureValueSets(vsList).should.be.fulfilled;
-    });
-
-    it('should not attempt downloads for value sets it already has (by https URL and version)', function () {
-      const vsList = [
-        {
-          name: 'HDL Cholesterol',
-          id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013',
-          version: '20170320'
-        }
-      ];
-      return service.ensureValueSets(vsList).should.be.fulfilled;
-    });
-
-    it('should not attempt downloads for value sets it already has (by http URL)', function () {
-      const vsList = [
-        {
-          name: 'HDL Cholesterol',
-          id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013'
-        }
-      ];
-      return service.ensureValueSets(vsList).should.be.fulfilled;
-    });
-
-    it('should not attempt downloads for value sets it already has (by http URL and version)', function () {
-      const vsList = [
-        {
-          name: 'HDL Cholesterol',
-          id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013',
-          version: '20170320'
-        }
-      ];
-      return service.ensureValueSets(vsList).should.be.fulfilled;
-    });
-
-    it('should not attempt downloads for value sets it already has (by https URL with embedded version)', function () {
-      const vsList = [
-        {
-          name: 'HDL Cholesterol',
-          id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20170320'
-        }
-      ];
-      return service.ensureValueSets(vsList).should.be.fulfilled;
-    });
-
-    it('should not attempt downloads for value sets it already has (by http URL with embedded version)', function () {
-      const vsList = [
-        {
-          name: 'HDL Cholesterol',
-          id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1013|20170320'
-        }
-      ];
-      return service.ensureValueSets(vsList).should.be.fulfilled;
-    });
-
-    it('should download value sets it does not have (by OID)', function () {
-      return doDownloadTest([
-        {
-          name: 'Systolic Blood Pressure',
-          id: '2.16.840.1.113883.3.526.3.1032'
-        },
-        { name: 'Current Tobacco Smoker', id: '2.16.840.1.113883.3.600.2390' }
-      ]);
-    });
-
-    it('should download value sets it does not have (by OID and version)', function () {
-      return doDownloadTest(
-        [
-          {
-            name: 'Systolic Blood Pressure',
-            id: '2.16.840.1.113883.3.526.3.1032',
-            version: '20170320'
-          },
-          {
-            name: 'Current Tobacco Smoker',
-            id: '2.16.840.1.113883.3.600.2390',
-            version: '20170320'
-          }
-        ],
-        true
-      );
-    });
-
-    it('should download value sets it does not have when no version is supplied (by URN)', function () {
-      return doDownloadTest([
-        {
-          name: 'Systolic Blood Pressure',
-          id: 'urn:oid:2.16.840.1.113883.3.526.3.1032'
-        },
-        {
-          name: 'Current Tobacco Smoker',
-          id: 'urn:oid:2.16.840.1.113883.3.600.2390'
-        }
-      ]);
-    });
-
-    it('should download value sets it does not have (by URN and version)', function () {
-      return doDownloadTest(
-        [
-          {
-            name: 'Systolic Blood Pressure',
-            id: 'urn:oid:2.16.840.1.113883.3.526.3.1032',
-            version: '20170320'
-          },
-          {
-            name: 'Current Tobacco Smoker',
-            id: 'urn:oid:2.16.840.1.113883.3.600.2390',
-            version: '20170320'
-          }
-        ],
-        true
-      );
-    });
-
-    it('should download value sets it does not have when no version is supplied (by https URL)', function () {
-      return doDownloadTest([
-        {
-          name: 'Systolic Blood Pressure',
-          id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032'
-        },
-        {
-          name: 'Current Tobacco Smoker',
-          id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390'
-        }
-      ]);
-    });
-
-    it('should download value sets it does not have (by https URL and version)', function () {
-      return doDownloadTest(
-        [
-          {
-            name: 'Systolic Blood Pressure',
-            id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032',
-            version: '20170320'
-          },
-          {
-            name: 'Current Tobacco Smoker',
-            id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390',
-            version: '20170320'
-          }
-        ],
-        true
-      );
-    });
-
-    it('should download value sets it does not have (by https URL with embedded version)', function () {
-      return doDownloadTest(
-        [
-          {
-            name: 'Systolic Blood Pressure',
-            id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032|20170320'
-          },
-          {
-            name: 'Current Tobacco Smoker',
-            id: 'https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390|20170320'
-          }
-        ],
-        true
-      );
-    });
-
-    it('should download value sets it does not have when no version is supplied (by http URL)', function () {
-      return doDownloadTest([
-        {
-          name: 'Systolic Blood Pressure',
-          id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032'
-        },
-        {
-          name: 'Current Tobacco Smoker',
-          id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390'
-        }
-      ]);
-    });
-
-    it('should download value sets it does not have (by http URL and version)', function () {
-      return doDownloadTest(
-        [
-          {
-            name: 'Systolic Blood Pressure',
-            id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032',
-            version: '20170320'
-          },
-          {
-            name: 'Current Tobacco Smoker',
-            id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390',
-            version: '20170320'
-          }
-        ],
-        true
-      );
-    });
-
-    it('should download value sets it does not have (by http URL with embedded version)', function () {
-      return doDownloadTest(
-        [
-          {
-            name: 'Systolic Blood Pressure',
-            id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1032|20170320'
-          },
-          {
-            name: 'Current Tobacco Smoker',
-            id: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2390|20170320'
-          }
-        ],
-        true
-      );
-    });
-
-    const doDownloadTest = (vsList, withVersion = false) => {
-      // Just to be sure, check length is only 2 (as expected)
-      Object.keys(service.valueSets).should.have.length(2);
-
-      const query1 = {
-        id: '2.16.840.1.113883.3.526.3.1032',
-        ticket: 'ST-TEST-1'
-      };
-      const query2 = {
-        id: '2.16.840.1.113883.3.600.2390',
-        ticket: 'ST-TEST-2'
-      };
-      if (withVersion) {
-        query1.version = '20170320';
-        query2.version = '20170320';
-      }
-      nock('https://vsac.nlm.nih.gov')
-        // Ticket granting ticket
-        .post('/vsac/ws/Ticket', { username, password })
-        .reply(200, 'TGT-TEST')
-        // Service ticket and VS retrieval #1
-        .post('/vsac/ws/Ticket/TGT-TEST', {
-          service: 'http://umlsks.nlm.nih.gov'
-        })
-        .reply(200, 'ST-TEST-1')
-        .get('/vsac/svs/RetrieveValueSet')
-        .query(query1)
-        .replyWithFile(200, path.join(__dirname, 'fixtures', '2.16.840.1.113883.3.526.3.1032.xml'))
-        // Service ticket and VS retrieval #2
-        .post('/vsac/ws/Ticket/TGT-TEST', {
-          service: 'http://umlsks.nlm.nih.gov'
-        })
-        .reply(200, 'ST-TEST-2')
-        .get('/vsac/svs/RetrieveValueSet')
-        .query(query2)
-        .replyWithFile(200, path.join(__dirname, 'fixtures', '2.16.840.1.113883.3.600.2390.xml'));
-
-      return service.ensureValueSets(vsList, username, password).then(function () {
-        // Test that the value sets were properly loaded into memory
-        service.valueSets.should.not.be.empty;
-        Object.keys(service.valueSets).should.have.length(4);
-        const vs1 = service.findValueSet('2.16.840.1.113883.3.526.3.1032', '20170320');
-        vs1.codes.should.have.length(1);
-        const vs2 = service.findValueSet('2.16.840.1.113883.3.600.2390', '20170418');
-        vs2.codes.should.have.length(24);
-        // Test that the value sets were properly written to the cache
-        const cached = require(path.join(tmpCache, 'valueset-db.json'));
-        JSON.parse(JSON.stringify(service.valueSets)).should.eql(cached);
-      }); //.catch((err) => console.log(err));
-    };
-  });
-
   //Updated tests for use with API Key based auth
   describe('#ensureValueSetsWithAPIKey', function () {
     it('should not attempt downloads for value sets it already has (by OID)', function () {
@@ -1095,7 +778,7 @@ describe('CodeService', function () {
 
       nock('https://vsac.nlm.nih.gov')
         // Ticket granting ticket
-        .post('/vsac/ws/Ticket', { username, password })
+        .post('/vsac/ws/Ticket', { apikey: apiKey })
         .reply(200, 'TGT-TEST')
         // Service ticket and VS retrieval #1
         .post('/vsac/ws/Ticket/TGT-TEST', {
@@ -1136,7 +819,7 @@ describe('CodeService', function () {
       ];
 
       return service
-        .ensureValueSets(vsList, username, password)
+        .ensureValueSetsWithAPIKey(vsList, apiKey)
         .then(function () {
           should.fail(0, 1, 'This code should never be executed since there were errors');
         })
@@ -1158,66 +841,10 @@ describe('CodeService', function () {
         });
     });
 
-    it('should error if no username/password is supplied', function () {
-      const [oldU, oldP] = [process.env['UMLS_USER_NAME'], process.env['UMLS_PASSWORD']];
-      try {
-        // Make sure env is clear so no username/password creeps through!
-        delete process.env['UMLS_USER_NAME'];
-        delete process.env['UMLS_PASSWORD'];
-
-        nock('https://vsac.nlm.nih.gov');
-
-        const vsList = [
-          {
-            name: 'Systolic Blood Pressure',
-            id: '2.16.840.1.113883.3.526.3.1032',
-            version: '20170320'
-          }
-        ];
-        return service
-          .ensureValueSets(vsList, null, null)
-          .then(function () {
-            should.fail(0, 1, 'This code should never be executed');
-          })
-          .catch(function (error) {
-            error.should.eql(
-              'Failed to download value sets since UMLS_USER_NAME and/or UMLS_PASSWORD is not set.'
-            );
-          });
-      } finally {
-        [process.env['UMLS_USER_NAME'], process.env['UMLS_PASSWORD']] = [oldU, oldP];
-      }
-    });
-
-    it('should error if wrong username/password is supplied', function () {
-      const [wrongU, wrongP] = ['foo', 'bar'];
-      nock('https://vsac.nlm.nih.gov')
-        // Simulate response to requesting ticket granting ticket w/ wrong username/password
-        .post('/vsac/ws/Ticket', { username: wrongU, password: wrongP })
-        .reply(401); // Unauthorized
-
-      const vsList = [
-        {
-          name: 'Systolic Blood Pressure',
-          id: '2.16.840.1.113883.3.526.3.1032',
-          version: '20170320'
-        }
-      ];
-
-      return service
-        .ensureValueSets(vsList, wrongU, wrongP)
-        .then(function () {
-          should.fail(0, 1, 'This code should never be executed');
-        })
-        .catch(function (error) {
-          error.message.should.equal('401');
-        });
-    });
-
     it('should error if no API Key is supplied', function () {
       const oldAPIKey = process.env['UMLS_API_KEY'];
       try {
-        // Make sure env is clear so no username/password creeps through!
+        // Make sure env is clear so no API key creeps through!
         delete process.env['UMLS_API_KEY'];
 
         nock('https://vsac.nlm.nih.gov');
@@ -1240,37 +867,6 @@ describe('CodeService', function () {
       } finally {
         process.env['UMLS_API_KEY'] = oldAPIKey;
       }
-    });
-
-    it('should error if invalid ticket granting ticket is supplied', function () {
-      // Technically this should only happen if there is an issue w/ VSAC, but let's be sure we handle it
-      nock('https://vsac.nlm.nih.gov')
-        // Ticket granting ticket (invalid)
-        .post('/vsac/ws/Ticket', { username, password })
-        .reply(200, 'TGT-INVALID-TEST')
-        // Simulate response to requesting service granting ticket w/ invalid ticket granting ticket
-        .post('/vsac/ws/Ticket/TGT-INVALID-TEST', {
-          service: 'http://umlsks.nlm.nih.gov'
-        })
-        .reply(401); // Unauthorized
-
-      const vsList = [
-        {
-          name: 'Systolic Blood Pressure',
-          id: '2.16.840.1.113883.3.526.3.1032',
-          version: '20170320'
-        }
-      ];
-      return service
-        .ensureValueSets(vsList, username, password)
-        .then(function () {
-          should.fail(0, 1, 'This code should never be executed');
-        })
-        .catch(function (error) {
-          error.should.have.length(1);
-          error[0].should.be.an('error');
-          error[0].message.should.contain('2.16.840.1.113883.3.526.3.1032');
-        });
     });
 
     it('should error if invalid ticket granting ticket is supplied using API key functions', function () {
@@ -1308,7 +904,7 @@ describe('CodeService', function () {
       // Technically this should only happen if there is an issue w/ VSAC, but let's be sure we handle it
       nock('https://vsac.nlm.nih.gov')
         // Ticket granting ticket
-        .post('/vsac/ws/Ticket', { username, password })
+        .post('/vsac/ws/Ticket', { apikey: apiKey })
         .reply(200, 'TGT-TEST')
         // Service ticket (invalid)
         .post('/vsac/ws/Ticket/TGT-TEST', {
@@ -1332,7 +928,7 @@ describe('CodeService', function () {
         }
       ];
       return service
-        .ensureValueSets(vsList, username, password)
+        .ensureValueSetsWithAPIKey(vsList, apiKey)
         .then(function () {
           should.fail(0, 1, 'This code should never be executed');
         })
@@ -1347,7 +943,7 @@ describe('CodeService', function () {
       // Technically this should only happen if there is an issue w/ VSAC, but let's be sure we handle it
       nock('https://vsac.nlm.nih.gov')
         // Ticket granting ticket
-        .post('/vsac/ws/Ticket', { username, password })
+        .post('/vsac/ws/Ticket', { apikey: apiKey })
         .reply(200, 'TGT-TEST')
         // Service ticket and VS retrieval #1
         .post('/vsac/ws/Ticket/TGT-TEST', {
@@ -1370,7 +966,7 @@ describe('CodeService', function () {
         }
       ];
       return service
-        .ensureValueSets(vsList, username, password)
+        .ensureValueSetsWithAPIKey(vsList, apiKey)
         .then(function () {
           should.fail(0, 1, 'This code should never be executed');
         })


### PR DESCRIPTION
The `ensureValueSets` and `ensureValueSetsInLibrary` methods no longer work because VSAC does not support username/password authentication anymore. These were deprecated in later versions of 1.x and are now being removed for version 2.x.