### PR TITLE
Use BasicAuth instead of TGT authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2032,9 +2032,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -930,9 +930,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"


### PR DESCRIPTION
NLM has deprecated the Ticket-Granting-Ticket authentication mechanism. BasicAuth should be used instead.

The easiest way to test this is by running the `manual-test.js` file. If your `UMLS_API_KEY` environment variable is set to a valid key, you should see output like this:
```
CALL: codeService.findValueSet(2.16.840.1.113883.3.464.1003.104.12.1013)
EXPECT: undefined
RESULT: undefined

CALL: codeService.ensureValueSetsWithAPIKey(['{"name":"HDL Cholesterol","id":"2.16.840.1.113883.3.464.1003.104.12.1013"}'], env['UMLS_API_KEY'], false);
EXPECT: <void>
RESULT: <void>

CALL: codeService.findValueSet(2.16.840.1.113883.3.464.1003.104.12.1013)
EXPECT: <valueSet w/ two codes>
RESULT: {
  "oid": "2.16.840.1.113883.3.464.1003.104.12.1013",
  "version": "Latest",
  "codes": [
    {
      "code": "2093-3",
      "system": "http://loinc.org",
      "version": "2.74"
    },
    {
      "code": "48620-9",
      "system": "http://loinc.org",
      "version": "2.74"
    }
  ]
}
```

After confirming that, try setting your `UMLS_API_KEY` environment variable to an invalid value and confirm that `manual-test.js` returns an error.